### PR TITLE
Start websocket server on same port as webserver

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -23,9 +23,7 @@ var config = {
 
     /**
      * The port for the server and websocket
-     * The given number is the one for the webinterface
-     * The given number + 1 is the websocket port
-     * Notice that both given number and the number+1 will be required
+     * The given number is the one for the webinterface and websocket
      */
     "port": 4326
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -7,6 +7,7 @@ var express = require('express');
 var path = require('path');
 var app = express();
 var config = require(__dirname + "/config");
+var http = require('http');
 
 app.get("/", function (req, res) {
     res.sendFile(path.resolve(__dirname + "/../public/index.html"));
@@ -14,11 +15,14 @@ app.get("/", function (req, res) {
 
 // output the required ws port number
 app.get("/wsconfig", function (req, res) {
-    res.send(JSON.stringify({port : config.port + 1, sslUrl : config.websocketUrlSsl, url : config.websocketUrl}));
+    res.send(JSON.stringify({port : config.port, sslUrl : config.websocketUrlSsl, url : config.websocketUrl}));
 });
 
 app.use(express.static(__dirname + "/../public"));
 
-app.listen(config.port, config.host, function () {
+var server = http.createServer(app);
+server.listen(config.port, config.host, function () {
 
 });
+
+module.exports = server;

--- a/src/websocketmgr.js
+++ b/src/websocketmgr.js
@@ -15,13 +15,15 @@ var WebSocketMgr = {};
  */
 WebSocketMgr.server = null;
 
+var server = require('./routes');
+
 /**
  * Start the websocket server
  */
 WebSocketMgr.startServer = function () {
     try {
         if (WebSocketMgr.server === null) {
-            WebSocketMgr.server = new WebSocketServer({port: config.port + 1});
+            WebSocketMgr.server = new WebSocketServer({server});
             WebSocketMgr.server.on('connection', function connection(ws) {
                 var user = new WebSocketUser(ws);
                 ws.on('message', function incoming(message) {


### PR DESCRIPTION
I couldn't find a rationale on why the websocket is started on a separate port, and it adds needless complexity to have it spread on two ports, where one is hardcoded to be one higher than the webserver port.